### PR TITLE
fix: memoize FloatingShape to prevent mobile re-renders

### DIFF
--- a/packages/website/src/components/home/floating-shape.tsx
+++ b/packages/website/src/components/home/floating-shape.tsx
@@ -85,7 +85,7 @@ const PixelLoader = memo(function PixelLoader() {
   );
 });
 
-export function FloatingShape() {
+export const FloatingShape = memo(function FloatingShape() {
   const [loaded, setLoaded] = useState(false);
 
   const onLoad = useCallback((splineApp: Application) => {
@@ -134,4 +134,4 @@ export function FloatingShape() {
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Bug

On mobile (iOS Safari), the browser dynamically resizes the viewport as the address bar appears/disappears. This fires events that framer-motion's `useScroll` hook (inside `Hero`) picks up internally, causing `Hero` to re-render. Since `FloatingShape` was not memoized, the expensive Spline WebGL canvas re-rendered on every tick — producing visible flickering that appeared to coincide with the clock updating every second.

The issue was mobile-only because on desktop the viewport is stable and `useScroll` doesn't trigger `Hero` re-renders.

## Fix

Wrapped `FloatingShape` in `React.memo()`. Since it receives zero props, it will never re-render due to parent re-renders, protecting the Spline 3D scene from being recreated unnecessarily.

```diff
- export function FloatingShape() {
+ export const FloatingShape = memo(function FloatingShape() {
  ...
- }
+ });
```

**File changed:** `packages/website/src/components/home/floating-shape.tsx`

> Note: `LocalClock` was already correctly isolated in its own `memo()` component — no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)